### PR TITLE
The setup should not depend on the module it is setting up nor any depen...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 # Filename: setup.py
 
 from distutils.core import setup
-from ipwhois import __version__
 import sys
 
 NAME = 'ipwhois'
-VERSION = __version__
+VERSION = "0.8.2"
 AUTHOR = "Philip Hane"
 AUTHOR_EMAIL = "secynic AT gmail DOT com"
 DESCRIPTION = "IP Whois Resolution and Parsing"


### PR DESCRIPTION
...dencies which would be resolved after the setup.

I've come across an issue when installing ipwhois.

When, for example installing from pip:
    pip install ipwhois

results in this error:
    ImportError: No module named 'dns'

This is because the setup.py file acquires the version number from the ipwhois module and thus depends on it.

The problem is that setup.py depends on ipwhois which depends on dnspython.
However, since setup.py hasn't installed the dependencies for ipwhois yet, the setup fails.

The solution could be:
Install the dns module before even attempting to install ipwhois.

This, however, is not a feasible solution for deployments such as Heroku, Openshift and other "butt" providers since the gears/nodes sometimes spin down and then, when using the requirements.txt flle to install the dependencies again, will fail.

This is because pip features "look before you leap" - pip ensures that all dependencies can be found, unpacked, and have working setup.py before it installs any of them. source: post #3 https://github.com/pypa/pip/issues/25.

A better solution would be to not having to import ipwhois in the actual setup.py file, as is shown in this pull request.
