### PR TITLE
Add support for parsing organisation same as role for contact info

### DIFF
--- a/ipwhois/ipwhois.py
+++ b/ipwhois/ipwhois.py
@@ -1418,7 +1418,7 @@ class IPWhois:
 
             try:
 
-                if n['type'] == 'role':
+                if n['type'] == 'role' or n['type'] == 'organisation':
 
                     for attr in n['attributes']['attribute']:
 


### PR DESCRIPTION
In WHOIS for my Digital Ocean host in their Frankfurt data center (RIPE), the abuse contact is returned under an object with type 'organisation' instead of 'role'. Making this line check for that object type as well results in the abuse email being parsed correctly, without negatively affecting parsing of the provided RIPE test case.