### PR TITLE
using decode('ascii', 'ignore') changes asn name

### DIFF
--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -494,7 +494,7 @@ class Net:
             try:
                 d = json.loads(data.readall().decode())
             except AttributeError:  # pragma: no cover
-                d = json.loads(data.read().decode('ascii', 'ignore'))
+                d = json.loads(data.read().decode('utf-8'))
 
             return d
 


### PR DESCRIPTION
Some asnames have special characters like âçã and using decode('ascii', 'ignore') removes them, which, as I see, is not a good thing as it changes source data. This change fixes the problem.