### PR TITLE
Handle 429 rate-limit status code

### DIFF
--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -681,6 +681,10 @@ class Net:
 
         except (URLError, socket.timeout, socket.error) as e:
 
+            if isinstance(e, URLError):
+                if e.getcode() == 429:
+                    raise HTTPRateLimitError
+
             # Check needed for Python 2.6, also why URLError is caught.
             try:  # pragma: no cover
                 if not isinstance(e.reason, (socket.timeout, socket.error)):


### PR DESCRIPTION
Currently RIPE will return a generic html page with status code 429 when the client is rate-limited and not a json as expected.