### PR TITLE
Parse 'route6' entries from RADB ASN network lookups

### DIFF
--- a/ipwhois/asn.py
+++ b/ipwhois/asn.py
@@ -518,9 +518,9 @@ class ASNOrigin:
         nets = []
 
         if is_http:
-            regex = r'route:[^\S\n]+(?P<val>.+?)<br>'
+            regex = r'route(?:6)?:[^\S\n]+(?P<val>.+?)<br>'
         else:
-            regex = r'^route:[^\S\n]+(?P<val>.+|.+)$'
+            regex = r'^route(?:6)?:[^\S\n]+(?P<val>.+|.+)$'
 
         # Iterate through all of the networks found, storing the CIDR value
         # and the start and end positions.


### PR DESCRIPTION
Hi @secynic, thanks for the great library.

This is a small fix to return IPv6 prefixes from ASN reverse origin lookups from RADB. Below is an example response:

```
route6:     2a04:e800::/29
descr:      Blizzard Entertainment
origin:     AS57976
mnt-by:     MAINT-AS57976
changed:    peering@blizzard.com 20151103  #22:18:12Z
source:     RADB
```

.. and its parsed counterpart:

```
          {'cidr': '2a04:e800::/29',
           'description': 'Blizzard Entertainment',
           'maintainer': 'MAINT-AS57976',
           'source': 'RADB',
           'updated': 'peering@blizzard.com 20151103  #22:18:12Z'},
```

I'm very unfamiliar with the codebase, so I'm not aware of any historical assumptions of `ASNOrigin.lookup()` returning IPv4 addresses only. Perhaps we could split the return value into `nets_ipv4` and `nets_ipv6` to make it easier for consumers?

Cheers!