### PR TITLE
Make use of builtin sphinx napoleon extension

### DIFF
--- a/ipwhois/docs/requirements.txt
+++ b/ipwhois/docs/requirements.txt
@@ -1,4 +1,3 @@
 sphinx
-sphinxcontrib-napoleon
 sphinx_rtd_theme
 dnspython

--- a/ipwhois/docs/source/conf.py
+++ b/ipwhois/docs/source/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.napoleon'
+    'sphinx.ext.napoleon'
 ]
 
 napoleon_google_docstring = True


### PR DESCRIPTION
Since 1.3b1 (released Oct 10, 2014) Sphinx has support for NumPy and
Google style docstring support via sphinx.ext.napoleon extension.

The sphinxcontrib.napoleon extension will continue to work with
Sphinx <= 1.2.
