### PR TITLE
Allow querying RDAP IP Networks

### DIFF
--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -50,8 +50,7 @@ if sys.version_info >= (3, 3):  # pragma: no cover
 else:  # pragma: no cover
     from ipaddr import (IPAddress as ip_address,
                         IPv4Address,
-                        IPv6Address
-                        )
+                        IPv6Address)
 
 try:  # pragma: no cover
     from urllib.request import (OpenerDirector,

--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -43,11 +43,15 @@ from .utils import ipv4_is_defined, ipv6_is_defined
 if sys.version_info >= (3, 3):  # pragma: no cover
     from ipaddress import (ip_address,
                            IPv4Address,
-                           IPv6Address)
+                           IPv6Address,
+                           ip_network,
+                           IPv4Network,
+                           IPv6Network)
 else:  # pragma: no cover
     from ipaddr import (IPAddress as ip_address,
                         IPv4Address,
-                        IPv6Address)
+                        IPv6Address
+                        )
 
 try:  # pragma: no cover
     from urllib.request import (OpenerDirector,
@@ -117,9 +121,14 @@ class Net:
 
         # IPv4Address or IPv6Address
         if isinstance(address, IPv4Address) or isinstance(
-                address, IPv6Address):
+                address, IPv6Address) or isinstance(
+                address, IPv4Network) or isinstance(address, IPv6Network):
 
             self.address = address
+
+        elif isinstance(address, str) and '/' in address:
+
+            self.address = ip_network(address)
 
         else:
 
@@ -161,8 +170,16 @@ class Net:
 
         if self.version == 4:
 
-            # Check if no ASN/whois resolution needs to occur.
-            is_defined = ipv4_is_defined(self.address_str)
+            if isinstance(self.address, IPv4Network):
+
+                # Check if no ASN/whois resolution needs to occur with the
+                # first IP in the subnet.
+                is_defined = ipv4_is_defined(next(self.address.hosts()))
+
+            else:
+
+                # Check if no ASN/whois resolution needs to occur.
+                is_defined = ipv4_is_defined(self.address_str)
 
             if is_defined[0]:
 
@@ -182,8 +199,16 @@ class Net:
 
         else:
 
-            # Check if no ASN/whois resolution needs to occur.
-            is_defined = ipv6_is_defined(self.address_str)
+            if isinstance(self.address, IPv6Network):
+
+                # Check if no ASN/whois resolution needs to occur with the
+                # first IP in the subnet.
+                is_defined = ipv6_is_defined(next(self.address.hosts()))
+
+            else:
+
+                # Check if no ASN/whois resolution needs to occur.
+                is_defined = ipv6_is_defined(self.address_str)
 
             if is_defined[0]:
 

--- a/ipwhois/tests/test_net.py
+++ b/ipwhois/tests/test_net.py
@@ -16,22 +16,34 @@ class TestNet(TestCommon):
     def test_ip_invalid(self):
         self.assertRaises(ValueError, Net, '192.168.0.256')
         self.assertRaises(ValueError, Net, 'fe::80::')
+        self.assertRaises(ValueError, Net, '192.256.0.0/16')
+        self.assertRaises(ValueError, Net, 'fe::80::/10')
 
     def test_ip_defined(self):
         if sys.version_info >= (3, 3):
-            from ipaddress import (IPv4Address, IPv6Address)
+            from ipaddress import (IPv4Address, IPv6Address, 
+                    IPv4Network, IPv6Network)
         else:
-            from ipaddr import (IPv4Address, IPv6Address)
+            from ipaddr import (IPv4Address, IPv6Address,
+                    IPv4Network, IPv6Network)
 
         self.assertRaises(IPDefinedError, Net, '192.168.0.1')
         self.assertRaises(IPDefinedError, Net, 'fe80::')
         self.assertRaises(IPDefinedError, Net, IPv4Address('192.168.0.1'))
         self.assertRaises(IPDefinedError, Net, IPv6Address('fe80::'))
+        self.assertRaises(IPDefinedError, Net, '192.168.0.0/16')
+        self.assertRaises(IPDefinedError, Net, 'fe80::/10')
+        self.assertRaises(IPDefinedError, Net, IPv4Network('192.168.0.0/16'))
+        self.assertRaises(IPDefinedError, Net, IPv6Network('fe80::/10'))
 
     def test_ip_version(self):
         result = Net('74.125.225.229')
         self.assertEqual(result.version, 4)
         result = Net('2001:4860:4860::8888')
+        self.assertEqual(result.version, 6)
+        result = Net('8.8.8.0/24')
+        self.assertEqual(result.version, 4)
+        result = Net('2001:4860::/32')
         self.assertEqual(result.version, 6)
 
     def test_timeout(self):


### PR DESCRIPTION
These changes permit to query a subnet instead of an IP. This is handy for overlapping subnets. I made sure the is_defined test is still performed. 

Solves #250 