### PR TITLE
Allow to queries IP prefixes

### DIFF
--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -40,17 +40,12 @@ from .whois import RIR_WHOIS
 from .asn import ASN_ORIGIN_WHOIS
 from .utils import ipv4_is_defined, ipv6_is_defined
 
-if sys.version_info >= (3, 3):  # pragma: no cover
-    from ipaddress import (ip_address,
-                           IPv4Address,
-                           IPv6Address,
-                           ip_network,
-                           IPv4Network,
-                           IPv6Network)
-else:  # pragma: no cover
-    from ipaddr import (IPAddress as ip_address,
+from ipaddress import (ip_address,
                         IPv4Address,
-                        IPv6Address)
+                        IPv6Address,
+                        ip_network,
+                        IPv4Network,
+                        IPv6Network)
 
 try:  # pragma: no cover
     from urllib.request import (OpenerDirector,
@@ -68,6 +63,12 @@ except ImportError:  # pragma: no cover
                          URLError,
                          HTTPError)
     from urllib import urlencode
+
+if sys.version_info >= (3, 3):  # pragma: no cover
+    # There is no builtin unicode function in Python3, all strings are unicode
+    # in Python3
+    def unicode(string):
+        return string
 
 log = logging.getLogger(__name__)
 
@@ -123,12 +124,12 @@ class Net:
 
         elif isinstance(address, str) and '/' in address:
 
-            self.address = ip_network(address)
+            self.address = ip_network(unicode(address))
 
         else:
 
             # Use ipaddress package exception handling.
-            self.address = ip_address(address)
+            self.address = ip_address(unicode(address))
 
         # Default timeout for socket connections.
         self.timeout = timeout

--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -43,7 +43,10 @@ from .utils import ipv4_is_defined, ipv6_is_defined
 if sys.version_info >= (3, 3):  # pragma: no cover
     from ipaddress import (ip_address,
                            IPv4Address,
-                           IPv6Address)
+                           IPv6Address,
+                           ip_network,
+                           IPv4Network,
+                           IPv6Network)
 else:  # pragma: no cover
     from ipaddr import (IPAddress as ip_address,
                         IPv4Address,
@@ -113,9 +116,14 @@ class Net:
 
         # IPv4Address or IPv6Address
         if isinstance(address, IPv4Address) or isinstance(
-                address, IPv6Address):
+                address, IPv6Address) or isinstance(
+                address, IPv4Network) or isinstance(address, IPv6Network):
 
             self.address = address
+
+        elif isinstance(address, str) and '/' in address:
+
+            self.address = ip_network(address)
 
         else:
 
@@ -147,8 +155,16 @@ class Net:
 
         if self.version == 4:
 
-            # Check if no ASN/whois resolution needs to occur.
-            is_defined = ipv4_is_defined(self.address_str)
+            if isinstance(self.address, IPv4Network):
+
+                # Check if no ASN/whois resolution needs to occur with the
+                # first IP in the subnet.
+                is_defined = ipv4_is_defined(next(self.address.hosts()))
+
+            else:
+
+                # Check if no ASN/whois resolution needs to occur.
+                is_defined = ipv4_is_defined(self.address_str)
 
             if is_defined[0]:
 
@@ -168,8 +184,16 @@ class Net:
 
         else:
 
-            # Check if no ASN/whois resolution needs to occur.
-            is_defined = ipv6_is_defined(self.address_str)
+            if isinstance(self.address, IPv6Network):
+
+                # Check if no ASN/whois resolution needs to occur with the
+                # first IP in the subnet.
+                is_defined = ipv6_is_defined(next(self.address.hosts()))
+
+            else:
+
+                # Check if no ASN/whois resolution needs to occur.
+                is_defined = ipv6_is_defined(self.address_str)
 
             if is_defined[0]:
 

--- a/ipwhois/tests/test_net.py
+++ b/ipwhois/tests/test_net.py
@@ -16,22 +16,34 @@ class TestNet(TestCommon):
     def test_ip_invalid(self):
         self.assertRaises(ValueError, Net, '192.168.0.256')
         self.assertRaises(ValueError, Net, 'fe::80::')
+        self.assertRaises(ValueError, Net, '192.256.0.0/16')
+        self.assertRaises(ValueError, Net, 'fe::80::/10')
 
     def test_ip_defined(self):
         if sys.version_info >= (3, 3):
-            from ipaddress import (IPv4Address, IPv6Address)
+            from ipaddress import (IPv4Address, IPv6Address, 
+                    IPv4Network, IPv6Network)
         else:
-            from ipaddr import (IPv4Address, IPv6Address)
+            from ipaddr import (IPv4Address, IPv6Address,
+                    IPv4Network, IPv6Network)
 
         self.assertRaises(IPDefinedError, Net, '192.168.0.1')
         self.assertRaises(IPDefinedError, Net, 'fe80::')
         self.assertRaises(IPDefinedError, Net, IPv4Address('192.168.0.1'))
         self.assertRaises(IPDefinedError, Net, IPv6Address('fe80::'))
+        self.assertRaises(IPDefinedError, Net, '192.168.0.0/16')
+        self.assertRaises(IPDefinedError, Net, 'fe80::/10')
+        self.assertRaises(IPDefinedError, Net, IPv4Network('192.168.0.0/16'))
+        self.assertRaises(IPDefinedError, Net, IPv6Network('fe80::/10'))
 
     def test_ip_version(self):
         result = Net('74.125.225.229')
         self.assertEqual(result.version, 4)
         result = Net('2001:4860:4860::8888')
+        self.assertEqual(result.version, 6)
+        result = Net('8.8.8.0/24')
+        self.assertEqual(result.version, 4)
+        result = Net('2001:4860::/32')
         self.assertEqual(result.version, 6)
 
     def test_timeout(self):


### PR DESCRIPTION
This allows to query an IP prefix, for example 8.8.8.0/24 or 8.0.0.0/9
The is_defined check is done with the first IP in the range.

fixes #250 