### PR TITLE
fix AttributeError: 'NoneType' object has no attribute 'strip'

### DIFF
--- a/ipwhois/rdap.py
+++ b/ipwhois/rdap.py
@@ -551,7 +551,8 @@ class _RDAPNetwork(_RDAPCommon):
 
             try:
 
-                self.vars[v] = self.json[v].strip()
+                if self.json[v]:
+                    self.vars[v] = self.json[v].strip()
 
             except (KeyError, ValueError):
 


### PR DESCRIPTION
steps to reproduce:
from ipwhois import IPWhois
IPWhois("203.104.153.1").lookup_rdap()