### PR TITLE
Add 'get_recursive' option for legacy whois to RIPE NCC

### DIFF
--- a/ipwhois/ipwhois.py
+++ b/ipwhois/ipwhois.py
@@ -68,7 +68,7 @@ class IPWhois:
                      extra_blacklist=None, ignore_referral_errors=False,
                      field_list=None, extra_org_map=None,
                      inc_nir=True, nir_field_list=None, asn_methods=None,
-                     get_asn_description=True):
+                     get_asn_description=True, get_recursive=True):
         """
         The function for retrieving and parsing whois information for an IP
         address via port 43 (WHOIS).
@@ -113,6 +113,10 @@ class IPWhois:
             get_asn_description (:obj:`bool`): Whether to run an additional
                 query when pulling ASN information via dns, in order to get
                 the ASN description. Defaults to True.
+            get_recursive (:obj:`bool`): Whether to ask the server to perform
+                recursive queries to get related objects. If False, passes
+                the '-r' flag to RIPE WHOIS servers. Has no effect for other
+                RIRs. Defaults to True.
 
         Returns:
             dict: The IP whois lookup results
@@ -167,7 +171,7 @@ class IPWhois:
             inc_raw=inc_raw, retry_count=retry_count, response=None,
             get_referral=get_referral, extra_blacklist=extra_blacklist,
             ignore_referral_errors=ignore_referral_errors, asn_data=asn_data,
-            field_list=field_list
+            field_list=field_list, get_recursive=get_recursive,
         )
 
         # Add the WHOIS information to the return dictionary.

--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -512,7 +512,7 @@ class Net:
             )
 
     def get_whois(self, asn_registry='arin', retry_count=3, server=None,
-                  port=43, extra_blacklist=None):
+                  port=43, extra_blacklist=None, get_recursive=True):
         """
         The function for retrieving whois or rwhois information for an IP
         address via any port. Defaults to port 43/tcp (WHOIS).
@@ -562,8 +562,9 @@ class Net:
             # Prep the query.
             query = self.address_str + '\r\n'
             if asn_registry == 'arin':
-
                 query = 'n + {0}'.format(query)
+            if asn_registry == 'ripencc' and get_recursive is False:
+                query = '-r {0}'.format(query)
 
             # Query the whois server, and store the results.
             conn.send(query.encode())

--- a/ipwhois/whois.py
+++ b/ipwhois/whois.py
@@ -550,7 +550,7 @@ class Whois:
     def lookup(self, inc_raw=False, retry_count=3, response=None,
                get_referral=False, extra_blacklist=None,
                ignore_referral_errors=False, asn_data=None,
-               field_list=None, is_offline=False):
+               field_list=None, is_offline=False, get_recursive=True):
         """
         The function for retrieving and parsing whois information for an IP
         address via port 43/tcp (WHOIS).
@@ -635,7 +635,7 @@ class Whois:
             # Retrieve the whois data.
             response = self._net.get_whois(
                 asn_registry=asn_data['asn_registry'], retry_count=retry_count,
-                extra_blacklist=extra_blacklist
+                extra_blacklist=extra_blacklist, get_recursive=get_recursive
             )
 
             if get_referral:


### PR DESCRIPTION
This patch adds an argument `get_recursive` to `lookup_whois()`. The
argument default is True, which causes no change to the behavior. If
the user passes `get_recursive=False`, and the IP is allocated to
RIPE, this causes the `-r` flag to be included in the query string.
The `-r` flag asks RIPE WHOIS servers not to perform recursive
queries, such as for related "person" or "role" objects. This helps
users avoid IP blacklisting by RIPE.

The `-r` flag is only supported by RIPE, so this patch only affects
queries to RIPE servers.

Resolves #292 