### PR TITLE
Adding flexible workaround for dnspython v1.x and v2.x

### DIFF
--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -126,6 +126,11 @@ class Net:
         self.timeout = timeout
 
         self.dns_resolver = dns.resolver.Resolver()
+        if hasattr(self.dns_resolver, "resolve"):
+            self.dns_resolve = getattr(self.dns_resolver, "resolve")
+        else:
+            self.dns_resolve = getattr(self.dns_resolver, "query")
+        
         self.dns_resolver.timeout = timeout
         self.dns_resolver.lifetime = timeout
 
@@ -220,7 +225,7 @@ class Net:
         try:
 
             log.debug('ASN query for {0}'.format(self.dns_zone))
-            data = self.dns_resolver.resolve(self.dns_zone, 'TXT')
+            data = self.dns_resolve(self.dns_zone, 'TXT')
             return list(data)
 
         except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers,
@@ -262,7 +267,7 @@ class Net:
         try:
 
             log.debug('ASN verbose query for {0}'.format(zone))
-            data = self.dns_resolver.resolve(zone, 'TXT')
+            data = self.dns_resolve(zone, 'TXT')
             return str(data[0])
 
         except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers,

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ PACKAGES = ['ipwhois']
 
 PACKAGE_DATA = {'ipwhois': ['data/*.xml', 'data/*.csv']}
 
-INSTALL_REQUIRES = ['dnspython<=2.0.0', 'ipaddr==2.2.0;python_version<"3.3"']
+INSTALL_REQUIRES = ['dnspython<=3.0.0', 'ipaddr==2.2.0;python_version<"3.3"']
 
 setup(
     name=NAME,


### PR DESCRIPTION
v1.x Resolver().query and v1.x uses Resolver().resolve in net.net.py
This avoids deprecation warnings when using V2.x
Updated setup.py requirements to allow v2.x of dnspython to install with ipwhois.
Current pip versions warn or block conflicting dependency versions.