### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/ipwhois/tests/test_asn.py
+++ b/ipwhois/tests/test_asn.py
@@ -282,7 +282,7 @@ class TestASNOrigin(TestCommon):
             '\nsource:         AFRINIC'
             '\n\n'
         )
-        self.assertEquals(
+        self.assertEqual(
             obj.get_nets_radb(multi_net_response),
             [{
                 'updated': None,


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268