### PR TITLE
319 allow get_bulk_asn_whois to return a dictionary

### DIFF
--- a/EXPERIMENTAL.rst
+++ b/EXPERIMENTAL.rst
@@ -39,6 +39,9 @@ Arguments supported:
 | timeout            | int    | The default timeout for socket connections in |
 |                    |        | seconds. Defaults to 120.                     |
 +--------------------+--------+-----------------------------------------------+
+| as_dict            | bool   | Return the results as a dictionary instead of |
+|                    |        | a string. Defaults to False.                  |
++--------------------+--------+-----------------------------------------------+
 
 .. _get_bulk_asn_whois-output:
 
@@ -47,6 +50,8 @@ Output
 
 Outputs a string of the raw ASN bulk data, new line separated. The first line
 is obsolete.
+If as_dict set to True returns a dictionary with the IP address as the key and 
+ASN details in a dictionary as the value.
 
 .. _get_bulk_asn_whois-examples:
 

--- a/ipwhois/tests/online/test_experimental.py
+++ b/ipwhois/tests/online/test_experimental.py
@@ -30,6 +30,7 @@ class TestExperimental(TestCommon):
 
         try:
             self.assertIsInstance(get_bulk_asn_whois(addresses=ips), str)
+            self.assertIsInstance(get_bulk_asn_whois(addresses=ips, as_dict=True), dict)
         except ASNLookupError:
             pass
         except AssertionError as e:

--- a/ipwhois/tests/stress/test_experimental.py
+++ b/ipwhois/tests/stress/test_experimental.py
@@ -18,8 +18,7 @@ class TestExperimental(TestCommon):
                list(ipv6_generate_random(500)))
         try:
             self.assertIsInstance(get_bulk_asn_whois(addresses=ips), str)
-        except ASNLookupError:
-            pass
+            self.assertIsInstance(get_bulk_asn_whois(addresses=ips, as_dict=True), dict)
         except AssertionError as e:
             raise e
         except Exception as e:

--- a/ipwhois/tests/stress/test_net.py
+++ b/ipwhois/tests/stress/test_net.py
@@ -17,7 +17,7 @@ class TestNet(TestCommon):
         # Test for HTTPRateLimitError for up to 20 requests. Exits when raised.
         url = RIR_RDAP['lacnic']['ip_url'].format('200.57.141.161')
         result = Net('200.57.141.161')
-        count = 20
+        count = 100
         http_lookup_errors = 0
         while count > 0:
             log.debug('Attempts left: {0}'.format(str(count)))


### PR DESCRIPTION
Features added:
Added a parameter to allow get_bulk_asn_whois which allows the user to get a dictionary of data instead of the string of data.

Additional changes:
Restructured some of experimental.py in order to reduce code reuse.
Added tests and docs for the new feature change.
Updated some test parameters for tests that were failing locally.

Addresses #319 