### PR TITLE
Fix deprecation warning about query vs resolve

### DIFF
--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -220,7 +220,7 @@ class Net:
         try:
 
             log.debug('ASN query for {0}'.format(self.dns_zone))
-            data = self.dns_resolver.query(self.dns_zone, 'TXT')
+            data = self.dns_resolver.resolve(self.dns_zone, 'TXT')
             return list(data)
 
         except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers,
@@ -262,7 +262,7 @@ class Net:
         try:
 
             log.debug('ASN verbose query for {0}'.format(zone))
-            data = self.dns_resolver.query(zone, 'TXT')
+            data = self.dns_resolver.resolve(zone, 'TXT')
             return str(data[0])
 
         except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers,


### PR DESCRIPTION
  venv/lib64/python3.6/site-packages/ipwhois/net.py:223: DeprecationWarning: please use dns.resolver.Resolver.resolve() instead
    data = self.dns_resolver.query(self.dns_zone, 'TXT')

  venv/lib64/python3.6/site-packages/ipwhois/net.py:265: DeprecationWarning: please use dns.resolver.Resolver.resolve() instead
    data = self.dns_resolver.query(zone, 'TXT')