### PR TITLE
This fixes issue 324

### DIFF
--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -257,7 +257,7 @@ class Net:
 
             asn = 'AS{0}'.format(asn)
 
-        zone = '{0}.asn.cymru.com'.format(asn)
+        zone = '{0}.asn.cymru.com.'.format(asn)
 
         try:
 

--- a/ipwhois/net.py
+++ b/ipwhois/net.py
@@ -73,9 +73,9 @@ ARIN = 'http://whois.arin.net/rest/nets;q={0}?showDetails=true&showARIN=true'
 
 CYMRU_WHOIS = 'whois.cymru.com'
 
-IPV4_DNS_ZONE = '{0}.origin.asn.cymru.com'
+IPV4_DNS_ZONE = '{0}.origin.asn.cymru.com.'
 
-IPV6_DNS_ZONE = '{0}.origin6.asn.cymru.com'
+IPV6_DNS_ZONE = '{0}.origin6.asn.cymru.com.'
 
 BLACKLIST = [
     'root.rwhois.net'


### PR DESCRIPTION
I discovered a bug when ipwhois tries to resolve `cymru.com` domains. A dot is missing at the end of the domain names, causing errors when a local search domain is configured.