### PR TITLE
Fix ImportError: cannot import name 'main' when binaries are invoked by /usr/bin 

### DIFF
--- a/ipwhois/scripts/ipwhois_cli.py
+++ b/ipwhois/scripts/ipwhois_cli.py
@@ -1415,68 +1415,71 @@ class IPWhoisCLI:
 
         return output
 
+def main():
+    if script_args.addr:
 
-if script_args.addr:
+        results = IPWhoisCLI(
+            addr=script_args.addr[0],
+            timeout=script_args.timeout,
+            proxy_http=script_args.proxy_http if (
+                script_args.proxy_http and len(script_args.proxy_http) > 0
+            ) else None,
+            proxy_https=script_args.proxy_https if (
+                script_args.proxy_https and len(script_args.proxy_https) > 0
+            ) else None
+        )
 
-    results = IPWhoisCLI(
-        addr=script_args.addr[0],
-        timeout=script_args.timeout,
-        proxy_http=script_args.proxy_http if (
-            script_args.proxy_http and len(script_args.proxy_http) > 0
-        ) else None,
-        proxy_https=script_args.proxy_https if (
-            script_args.proxy_https and len(script_args.proxy_https) > 0
-        ) else None
-    )
+        if script_args.whois:
 
-    if script_args.whois:
+            print(results.lookup_whois(
+                hr=script_args.hr,
+                show_name=script_args.show_name,
+                colorize=script_args.colorize,
+                inc_raw=script_args.inc_raw,
+                retry_count=script_args.retry_count,
+                get_referral=script_args.get_referral,
+                extra_blacklist=script_args.extra_blacklist.split(',') if (
+                    script_args.extra_blacklist and
+                    len(script_args.extra_blacklist) > 0) else None,
+                ignore_referral_errors=script_args.ignore_referral_errors,
+                field_list=script_args.field_list.split(',') if (
+                    script_args.field_list and
+                    len(script_args.field_list) > 0) else None,
+                extra_org_map=script_args.extra_org_map,
+                inc_nir=(not script_args.exclude_nir),
+                nir_field_list=script_args.nir_field_list.split(',') if (
+                    script_args.nir_field_list and
+                    len(script_args.nir_field_list) > 0) else None,
+                asn_methods=script_args.asn_methods.split(',') if (
+                    script_args.asn_methods and
+                    len(script_args.asn_methods) > 0) else None,
+                get_asn_description=(not script_args.skip_asn_description)
+            ))
 
-        print(results.lookup_whois(
-            hr=script_args.hr,
-            show_name=script_args.show_name,
-            colorize=script_args.colorize,
-            inc_raw=script_args.inc_raw,
-            retry_count=script_args.retry_count,
-            get_referral=script_args.get_referral,
-            extra_blacklist=script_args.extra_blacklist.split(',') if (
-                script_args.extra_blacklist and
-                len(script_args.extra_blacklist) > 0) else None,
-            ignore_referral_errors=script_args.ignore_referral_errors,
-            field_list=script_args.field_list.split(',') if (
-                script_args.field_list and
-                len(script_args.field_list) > 0) else None,
-            extra_org_map=script_args.extra_org_map,
-            inc_nir=(not script_args.exclude_nir),
-            nir_field_list=script_args.nir_field_list.split(',') if (
-                script_args.nir_field_list and
-                len(script_args.nir_field_list) > 0) else None,
-            asn_methods=script_args.asn_methods.split(',') if (
-                script_args.asn_methods and
-                len(script_args.asn_methods) > 0) else None,
-            get_asn_description=(not script_args.skip_asn_description)
-        ))
+        else:
 
-    else:
+            print(results.lookup_rdap(
+                hr=script_args.hr,
+                show_name=script_args.show_name,
+                colorize=script_args.colorize,
+                inc_raw=script_args.inc_raw,
+                retry_count=script_args.retry_count,
+                depth=script_args.depth,
+                excluded_entities=script_args.excluded_entities.split(',') if (
+                    script_args.excluded_entities and
+                    len(script_args.excluded_entities) > 0) else None,
+                bootstrap=script_args.bootstrap,
+                rate_limit_timeout=script_args.rate_limit_timeout,
+                extra_org_map=script_args.extra_org_map,
+                inc_nir=(not script_args.exclude_nir),
+                nir_field_list=script_args.nir_field_list.split(',') if (
+                    script_args.nir_field_list and
+                    len(script_args.nir_field_list) > 0) else None,
+                asn_methods=script_args.asn_methods.split(',') if (
+                    script_args.asn_methods and
+                    len(script_args.asn_methods) > 0) else None,
+                get_asn_description=(not script_args.skip_asn_description)
+            ))
 
-        print(results.lookup_rdap(
-            hr=script_args.hr,
-            show_name=script_args.show_name,
-            colorize=script_args.colorize,
-            inc_raw=script_args.inc_raw,
-            retry_count=script_args.retry_count,
-            depth=script_args.depth,
-            excluded_entities=script_args.excluded_entities.split(',') if (
-                script_args.excluded_entities and
-                len(script_args.excluded_entities) > 0) else None,
-            bootstrap=script_args.bootstrap,
-            rate_limit_timeout=script_args.rate_limit_timeout,
-            extra_org_map=script_args.extra_org_map,
-            inc_nir=(not script_args.exclude_nir),
-            nir_field_list=script_args.nir_field_list.split(',') if (
-                script_args.nir_field_list and
-                len(script_args.nir_field_list) > 0) else None,
-            asn_methods=script_args.asn_methods.split(',') if (
-                script_args.asn_methods and
-                len(script_args.asn_methods) > 0) else None,
-            get_asn_description=(not script_args.skip_asn_description)
-        ))
+if __name__ == "__main__":
+    main()

--- a/ipwhois/scripts/ipwhois_utils_cli.py
+++ b/ipwhois/scripts/ipwhois_utils_cli.py
@@ -128,187 +128,146 @@ group.add_argument(
          'platform consoles.'
 )
 
-# Get the args
-script_args = parser.parse_args()
+def main():
+    # Get the args
+    script_args = parser.parse_args()
+    if script_args.ipv4_lstrip_zeros:
+        print(ipv4_lstrip_zeros(address=script_args.ipv4_lstrip_zeros[0]))
 
-if script_args.ipv4_lstrip_zeros:
-
-    print(ipv4_lstrip_zeros(address=script_args.ipv4_lstrip_zeros[0]))
-
-elif script_args.calculate_cidr:
-
-    try:
-
-        result = calculate_cidr(
-            start_address=script_args.calculate_cidr[0],
-            end_address=script_args.calculate_cidr[1]
-        )
-
-        print('{0}Found {1} CIDR blocks for ({2}, {3}){4}:\n{5}'.format(
-            ANSI['green'] if script_args.colorize else '',
-            len(result),
-            script_args.calculate_cidr[0],
-            script_args.calculate_cidr[1],
-            ANSI['end'] if script_args.colorize else '',
-            '\n'.join(result)
-        ))
-
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.get_countries:
-
-    try:
-
-        result = get_countries()
-
-        print('{0}Found {1} countries{2}:\n{3}'.format(
-            ANSI['green'] if script_args.colorize else '',
-            len(result),
-            ANSI['end'] if script_args.colorize else '',
-            '\n'.join(['{0}: {1}'.format(k, v) for k, v in (
-                OrderedDict(sorted(result.items())).iteritems())])
-        ))
-
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.get_country:
-
-    try:
-
-        countries = get_countries()
-        result = countries[script_args.get_country[0].upper()]
-
-        print('{0}Match found for country code ({1}){2}:\n{3}'.format(
-            ANSI['green'] if script_args.colorize else '',
-            script_args.get_country[0],
-            ANSI['end'] if script_args.colorize else '',
-            result
-        ))
-
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.ipv4_is_defined:
-
-    try:
-
-        result = ipv4_is_defined(address=script_args.ipv4_is_defined[0])
-
-        if result[0]:
-            print('{0}{1} is defined{2}:\n{3}'.format(
+    elif script_args.calculate_cidr:
+        try:
+            result = calculate_cidr(
+                start_address=script_args.calculate_cidr[0],
+                end_address=script_args.calculate_cidr[1]
+            )
+            print('{0}Found {1} CIDR blocks for ({2}, {3}){4}:\n{5}'.format(
                 ANSI['green'] if script_args.colorize else '',
-                script_args.ipv4_is_defined[0],
+                len(result),
+                script_args.calculate_cidr[0],
+                script_args.calculate_cidr[1],
                 ANSI['end'] if script_args.colorize else '',
-                'Name: {0}\nRFC: {1}'.format(result[1], result[2])
+                '\n'.join(result)
             ))
-        else:
-            print('{0}{1} is not defined{2}'.format(
-                ANSI['yellow'] if script_args.colorize else '',
-                script_args.ipv4_is_defined[0],
-                ANSI['end'] if script_args.colorize else ''
-            ))
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
 
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.ipv6_is_defined:
-
-    try:
-
-        result = ipv6_is_defined(address=script_args.ipv6_is_defined[0])
-
-        if result[0]:
-            print('{0}{1} is defined{2}:\n{3}'.format(
+    elif script_args.get_countries:
+        try:
+            result = get_countries()
+            print('{0}Found {1} countries{2}:\n{3}'.format(
                 ANSI['green'] if script_args.colorize else '',
-                script_args.ipv6_is_defined[0],
+                len(result),
                 ANSI['end'] if script_args.colorize else '',
-                'Name: {0}\nRFC: {1}'.format(result[1], result[2])
+                '\n'.join(['{0}: {1}'.format(k, v) for k, v in (
+                    OrderedDict(sorted(result.items())).iteritems())])
             ))
-        else:
-            print('{0}{1} is not defined{2}'.format(
-                ANSI['yellow'] if script_args.colorize else '',
-                script_args.ipv6_is_defined[0],
-                ANSI['end'] if script_args.colorize else ''
-            ))
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
 
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.ipv4_generate_random:
-
-    try:
-
-        result = ipv4_generate_random(total=script_args.ipv4_generate_random[0])
-
-        for random_ip in result:
-
-            print(random_ip)
-
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.ipv6_generate_random:
-
-    try:
-
-        result = ipv6_generate_random(total=script_args.ipv6_generate_random[0])
-
-        for random_ip in result:
-
-            print(random_ip)
-
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.unique_everseen:
-
-    try:
-
-        result = list(unique_everseen(iterable=script_args.unique_everseen[0]))
-
-        print('{0}Unique everseen{1}:\n{2}'.format(
-            ANSI['green'] if script_args.colorize else '',
-            ANSI['end'] if script_args.colorize else '',
-            result
-        ))
-
-    except Exception as e:
-
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
-
-elif script_args.unique_addresses:
-
-    try:
-
-        result = unique_addresses(file_path=script_args.unique_addresses[0])
-
-        tmp = []
-        for k, v in sorted(result.items(), key=lambda kv: int(kv[1]['count']),
-                           reverse=True):
-            tmp.append('{0}{1}{2}: Count: {3}, Ports: {4}'.format(
-                ANSI['b'] if script_args.colorize else '',
-                k,
+    elif script_args.get_country:
+        try:
+            countries = get_countries()
+            result = countries[script_args.get_country[0].upper()]
+            print('{0}Match found for country code ({1}){2}:\n{3}'.format(
+                ANSI['green'] if script_args.colorize else '',
+                script_args.get_country[0],
                 ANSI['end'] if script_args.colorize else '',
-                v['count'],
-                json.dumps(v['ports'])
+                result
             ))
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
 
-        print('{0}Found {1} unique addresses{2}:\n{3}'.format(
-            ANSI['green'] if script_args.colorize else '',
-            len(result),
-            ANSI['end'] if script_args.colorize else '',
-            '\n'.join(tmp)
-        ))
+    elif script_args.ipv4_is_defined:
+        try:
+            result = ipv4_is_defined(address=script_args.ipv4_is_defined[0])
 
-    except Exception as e:
+            if result[0]:
+                print('{0}{1} is defined{2}:\n{3}'.format(
+                    ANSI['green'] if script_args.colorize else '',
+                    script_args.ipv4_is_defined[0],
+                    ANSI['end'] if script_args.colorize else '',
+                    'Name: {0}\nRFC: {1}'.format(result[1], result[2])
+                ))
+            else:
+                print('{0}{1} is not defined{2}'.format(
+                    ANSI['yellow'] if script_args.colorize else '',
+                    script_args.ipv4_is_defined[0],
+                    ANSI['end'] if script_args.colorize else ''
+                ))
 
-        print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
+
+    elif script_args.ipv6_is_defined:
+        try:
+            result = ipv6_is_defined(address=script_args.ipv6_is_defined[0])
+
+            if result[0]:
+                print('{0}{1} is defined{2}:\n{3}'.format(
+                    ANSI['green'] if script_args.colorize else '',
+                    script_args.ipv6_is_defined[0],
+                    ANSI['end'] if script_args.colorize else '',
+                    'Name: {0}\nRFC: {1}'.format(result[1], result[2])
+                ))
+            else:
+                print('{0}{1} is not defined{2}'.format(
+                    ANSI['yellow'] if script_args.colorize else '',
+                    script_args.ipv6_is_defined[0],
+                    ANSI['end'] if script_args.colorize else ''
+                ))
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
+
+    elif script_args.ipv4_generate_random:
+        try:
+            result = ipv4_generate_random(total=script_args.ipv4_generate_random[0])
+            for random_ip in result:
+                print(random_ip)
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
+
+    elif script_args.ipv6_generate_random:
+        try:
+            result = ipv6_generate_random(total=script_args.ipv6_generate_random[0])
+            for random_ip in result:
+                print(random_ip)
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
+
+    elif script_args.unique_everseen:
+        try:
+            result = list(unique_everseen(iterable=script_args.unique_everseen[0]))
+
+            print('{0}Unique everseen{1}:\n{2}'.format(
+                ANSI['green'] if script_args.colorize else '',
+                ANSI['end'] if script_args.colorize else '',
+                result
+            ))
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
+
+    elif script_args.unique_addresses:
+        try:
+            result = unique_addresses(file_path=script_args.unique_addresses[0])
+            tmp = []
+            for k, v in sorted(result.items(), key=lambda kv: int(kv[1]['count']),
+                               reverse=True):
+                tmp.append('{0}{1}{2}: Count: {3}, Ports: {4}'.format(
+                    ANSI['b'] if script_args.colorize else '',
+                    k,
+                    ANSI['end'] if script_args.colorize else '',
+                    v['count'],
+                    json.dumps(v['ports'])
+                ))
+
+            print('{0}Found {1} unique addresses{2}:\n{3}'.format(
+                ANSI['green'] if script_args.colorize else '',
+                len(result),
+                ANSI['end'] if script_args.colorize else '',
+                '\n'.join(tmp)
+            ))
+        except Exception as e:
+            print('{0}Error{1}: {2}'.format(ANSI['red'], ANSI['end'], str(e)))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When ipwhois install the CLI scripts in `/usr/bin` directory, when invoked, they produce the following error:
```
Traceback (most recent call last):
  File "/usr/bin/ipwhois_cli", line 5, in <module>
    from ipwhois.scripts.ipwhois_cli import main
ImportError: cannot import name 'main' from 'ipwhois.scripts.ipwhois_cli' (/usr/lib/python3.13/site-packages/ipwhois/scripts/ipwhois_cli.py)
```
It occurs because the original py scripts lack of `main` function.

This PR fixes the mentioned error.